### PR TITLE
Update the Twitter address in the standard configuration

### DIFF
--- a/_data/settings.yml
+++ b/_data/settings.yml
@@ -9,7 +9,7 @@ google-ID: "UA-112060364-1"
 # Available social icons are powered by Font Awesome, so you can use any icon that they offer
 social:
   - { icon: "github", link: "https://github.com/DimensionDev/Maskbook" }
-  - { icon: "twitter", link: "https://twitter.com/realmaskbook" }
+  - { icon: "twitter", link: "https://twitter.com/realMaskNetwork" }
   - { icon: "envelope", link: "mailto:info@dimension.im" }
   - { icon: "rss-square", link: "/feed.xml" }
 # - {icon: 'rss-square', link: '/rss-feed.xml'}

--- a/_includes/epilogue.html
+++ b/_includes/epilogue.html
@@ -14,7 +14,7 @@
 <h2>{% t epilogue_social_title %}</h2>
 
 <p><strong>Github</strong> <a href="https://github.com/DimensionDev">https://github.com/DimensionDev</a></p>
-<p><strong>Twitter</strong> <a href="https://twitter.com/realmaskbook">https://twitter.com/realmaskbook</a></p>
+<p><strong>Twitter</strong> <a href="https://twitter.com/realMaskNetwork">https://twitter.com/realMaskNetwork</a></p>
 <p><strong>Facebook</strong> <a href="https://www.facebook.com/masknetwork">https://www.facebook.com/masknetwork</a></p>
 <p><strong>Discord</strong> <a href="https://discord.com/invite/cKGW45g">https://discord.com/invite/cKGW45g</a></p>
 


### PR DESCRIPTION
Change the address From
https://twitter.com/realmaskbook
To
https://twitter.com/realMaskNetwork
This update does not include the address update of historical articles. 
Maybe it is better to keep the original address in those articles?(To be discussed)